### PR TITLE
Update Velocore adapter: mapping vote amount to the LVC token balance

### DIFF
--- a/adapters/velocore/src/index.ts
+++ b/adapters/velocore/src/index.ts
@@ -8,7 +8,7 @@ import {
   getUserStakesForAddressByPoolAtBlock,
   getUserVoteForAddressByPoolAtBlock,
 } from "./sdk/subgraphDetails";
-import { getGaugesAtBlock, VE_VC_ADDRESS } from "./sdk/lensDetails";
+import { getGaugesAtBlock, VC_ADDRESS } from "./sdk/lensDetails";
 import BigNumber from "bignumber.js";
 import { BlockData, OutputSchemaRow } from "./sdk/types";
 BigNumber.set({ EXPONENTIAL_AT: 256 });
@@ -81,7 +81,7 @@ export const getUserTVLByBlock = async ({
   userVotes.forEach((userVote) => {
     const user_address = userVote.owner.toLowerCase();
     const token_balance = userVote.balance;
-    const token_address = VE_VC_ADDRESS.toLowerCase();
+    const token_address = VC_ADDRESS.toLowerCase();
     tokenBalanceMap[user_address] = tokenBalanceMap[user_address] ?? {};
     tokenBalanceMap[user_address][token_address] = BigNumber(
       tokenBalanceMap[user_address][token_address] ?? 0

--- a/adapters/velocore/src/sdk/lensDetails.ts
+++ b/adapters/velocore/src/sdk/lensDetails.ts
@@ -34,6 +34,7 @@ export const getGaugesAtBlock = async (blockNumber: number) => {
 export const LENS_ADDRESS = "0xaA18cDb16a4DD88a59f4c2f45b5c91d009549e06";
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 export const VE_VC_ADDRESS = "0xAeC06345b26451bdA999d83b361BEaaD6eA93F87";
+export const VC_ADDRESS = "0xcc22F6AA610D1b2a0e89EF228079cB3e1831b1D1";
 export type PoolType = "cpmm" | "wombat" | "converter" | "veVC";
 
 export interface PoolRawData {


### PR DESCRIPTION
- Update Velocore adapter
    - To get the correct value of the vote amount from the coingecko api, we've updated to map the vote amount to the LVC token balance (not veLVC). 