### PR TITLE
fix: Problem pool (USD+)

### DIFF
--- a/adapters/lynex/src/sdk/config.ts
+++ b/adapters/lynex/src/sdk/config.ts
@@ -12,3 +12,7 @@ export const client = createPublicClient({
   chain: linea,
   transport: http("https://rpc.linea.build"),
 });
+
+export const PROBLEM_POOLS = {
+  '0x8dabf94c7bdd771e448a4ae4794cd71f9f3d7a0d': 0,
+} as any;

--- a/adapters/lynex/src/sdk/lensDetails.ts
+++ b/adapters/lynex/src/sdk/lensDetails.ts
@@ -7,7 +7,7 @@ import {
   MulticallParameters,
   PublicClient,
 } from "viem";
-import { client } from "./config";
+import { client, PROBLEM_POOLS } from "./config";
 import lensABI from "./abis/PairAPIABI.json";
 import veLYNXAbi from "./abis/veLYNX.json";
 
@@ -68,8 +68,9 @@ export const fetchUserPools = async (
   userPools: string[]
 ): Promise<LensResponseWithBlock[]> => {
   const publicClient = client;
+  const validPools = userPools.filter((pool) => PROBLEM_POOLS[pool] === undefined || PROBLEM_POOLS[pool] > blockNumber);
 
-  const calls = userPools.map((pool: string) => {
+  const calls = validPools.map((pool: string) => {
     return {
       address: LENS_ADDRESS,
       name: "getPair",


### PR DESCRIPTION
The USD+/EURO3 liquidity strategy broke after USD+ rebased to account for changes in their collateral. This made one our read multicall methods fail in this pipeline. For now we are excluding this strategy to address this issue. 