### PR TITLE
Gamma Strategies: address double counting issue

### DIFF
--- a/adapters/gammastrategies/src/index.ts
+++ b/adapters/gammastrategies/src/index.ts
@@ -54,6 +54,7 @@ const getAccountData = async (
           limitUpper,
         },
         shares,
+        sharesStaked,
       }
     }
   }`;
@@ -77,9 +78,15 @@ const getAccountData = async (
         continue;
       }
 
+      // Staked lynex positions are already accounted for by lynex adapter, exclude them here
+      const shares = hypeShare.shares - hypeShare.sharesStaked
+      if (shares <= 0) {
+        continue;
+      }
+
       accountHoldings[account.id] ??= {};
 
-      const shareOfPool = hypeShare.shares / hypeShare.hypervisor.totalSupply;
+      const shareOfPool = shares / hypeShare.hypervisor.totalSupply;
       const tvl0Share = Math.round(shareOfPool * hypeShare.hypervisor.tvl0);
       const tvl1Share = Math.round(shareOfPool * hypeShare.hypervisor.tvl1);
 

--- a/adapters/gammastrategies/src/index.ts
+++ b/adapters/gammastrategies/src/index.ts
@@ -166,6 +166,7 @@ export const getUserTVLByBlock = async (blocks: BlockData) => {
   const { blockNumber, blockTimestamp } = blocks;
   //    Retrieve data using block number and timestamp
 
+  // Exclude Nile as all positions already reflected in nile adapter
   const protocolData: AccountBalances[] = await Promise.all([
     getAccountData(PROTOCOLS.UNISWAP),
     getAccountData(PROTOCOLS.LYNEX),

--- a/adapters/gammastrategies/src/index.ts
+++ b/adapters/gammastrategies/src/index.ts
@@ -93,7 +93,7 @@ const getAccountData = async (
       const token0Address: string = hypeShare.hypervisor.pool.token0.id;
       const token1Address: string = hypeShare.hypervisor.pool.token1.id;
 
-      if (token0Address in accountHoldings) {
+      if (token0Address in accountHoldings[account.id]) {
         accountHoldings[account.id][token0Address].balance += tvl0Share;
       } else {
         accountHoldings[account.id][token0Address] = {
@@ -102,7 +102,7 @@ const getAccountData = async (
         };
       }
 
-      if (token1Address in accountHoldings) {
+      if (token1Address in accountHoldings[account.id]) {
         accountHoldings[account.id][token1Address].balance += tvl1Share;
       } else {
         accountHoldings[account.id][token1Address] = {

--- a/adapters/gammastrategies/src/index.ts
+++ b/adapters/gammastrategies/src/index.ts
@@ -171,7 +171,6 @@ export const getUserTVLByBlock = async (blocks: BlockData) => {
     getAccountData(PROTOCOLS.UNISWAP),
     getAccountData(PROTOCOLS.LYNEX),
     getAccountData(PROTOCOLS.LINEHUB),
-    getAccountData(PROTOCOLS.NILE),
   ]);
 
   const allProtocolHoldings: AccountBalances = {};


### PR DESCRIPTION
1. Lynex already counts staked shares, excluding it from gamma adapter to prevent double counting.
2. All Gamma/Nile positions are counted in Nile adapter, exclude here.
3. Fix token aggregation bug