### PR TITLE
Used the new subgraph for ZL

### DIFF
--- a/adapters/zerolend/src/sdk/tvl.ts
+++ b/adapters/zerolend/src/sdk/tvl.ts
@@ -13,7 +13,7 @@ const axiosInstance = rateLimit(axios.create(), {
 });
 
 const queryURL =
-  "https://api.goldsky.com/api/public/project_clsk1wzatdsls01wchl2e4n0y/subgraphs/zerolend-linea/1.0.0/gn";
+  "https://api.goldsky.com/api/public/project_clsk1wzatdsls01wchl2e4n0y/subgraphs/zerolend-obl-linea/1.0.0/gn";
 
 export const getUserTVLLegacyByBlock = async (
   blocks: BlockData

--- a/adapters/zerolend/src/sdk/tvl.ts
+++ b/adapters/zerolend/src/sdk/tvl.ts
@@ -13,7 +13,7 @@ const axiosInstance = rateLimit(axios.create(), {
 });
 
 const queryURL =
-  "https://api.goldsky.com/api/public/project_clsk1wzatdsls01wchl2e4n0y/subgraphs/zerolend-obl-linea/1.0.0/gn";
+  "https://api.goldsky.com/api/public/project_clsk1wzatdsls01wchl2e4n0y/subgraphs/zerolend-obl-linea/1.0.1/gn";
 
 export const getUserTVLLegacyByBlock = async (
   blocks: BlockData


### PR DESCRIPTION
Here we use a subgraph that has a much smaller set of events being tracked along with a proper calculation of interest rate calculation after a aToken update